### PR TITLE
Handle Long or Integer topology timeout

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,13 @@
 			<version>5.5.1</version>
 			<scope>test</scope>
 		</dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>1.9.5</version>
+            <scope>test</scope>
+        </dependency>
 	</dependencies>
 	<build>
 		<plugins>

--- a/src/main/java/backtype/storm/contrib/jms/spout/JmsSpout.java
+++ b/src/main/java/backtype/storm/contrib/jms/spout/JmsSpout.java
@@ -69,7 +69,6 @@ public class JmsSpout extends BaseRichSpout implements MessageListener {
 	
 	private boolean hasFailures = false;
 	public final Serializable recoveryMutex = "RECOVERY_MUTEX";
-	private Timer recoveryTimer = null;
 	private long recoveryPeriod = -1; // default to disabled
 	
 	/**
@@ -179,8 +178,8 @@ public class JmsSpout extends BaseRichSpout implements MessageListener {
 			consumer.setMessageListener(this);
 			this.connection.start();
 			if (this.isDurableSubscription() && this.recoveryPeriod > 0){
-			    this.recoveryTimer = new Timer();
-			    this.recoveryTimer.scheduleAtFixedRate(new RecoveryTask(), 10, this.recoveryPeriod);
+                Timer recoveryTimer = new Timer("JmsSpout-recovery-timer-" + context.getThisTaskId(), true);
+			    recoveryTimer.scheduleAtFixedRate(new RecoveryTask(), 10, this.recoveryPeriod);
 			}
 			
 		} catch (Exception e) {

--- a/src/test/java/backtype/storm/contrib/jms/spout/JmsSpoutTest.java
+++ b/src/test/java/backtype/storm/contrib/jms/spout/JmsSpoutTest.java
@@ -13,8 +13,10 @@ import javax.jms.MessageProducer;
 import javax.jms.Session;
 import javax.jms.TextMessage;
 
+import backtype.storm.task.TopologyContext;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.Mockito;
 import org.mortbay.log.Log;
 
 import backtype.storm.contrib.jms.JmsProvider;
@@ -22,7 +24,7 @@ import backtype.storm.spout.SpoutOutputCollector;
 
 public class JmsSpoutTest {
     @Test
-    public void testFailure() throws JMSException, Exception{
+    public void testFailure() throws Exception{
         JmsSpout spout = new JmsSpout();
         JmsProvider mockProvider = new MockJmsProvider();
         MockSpoutOutputCollector mockCollector = new MockSpoutOutputCollector();
@@ -31,7 +33,7 @@ public class JmsSpoutTest {
         spout.setJmsTupleProducer(new MockTupleProducer());
         spout.setJmsAcknowledgeMode(Session.CLIENT_ACKNOWLEDGE);
         spout.setRecoveryPeriod(10); // Rapid recovery for testing.
-        spout.open(new HashMap<String,String>(), null, collector);
+        spout.open(new HashMap<String,String>(), Mockito.mock(TopologyContext.class), collector);
         Message msg = this.sendMessage(mockProvider.connectionFactory(), mockProvider.destination());
         Thread.sleep(100);
         spout.nextTuple(); // Pretend to be storm.
@@ -54,7 +56,7 @@ public class JmsSpoutTest {
         oos.close();
         Assert.assertTrue(out.toByteArray().length > 0);
     }
-    
+
     public Message sendMessage(ConnectionFactory connectionFactory, Destination destination) throws JMSException {        
         Session mySess = connectionFactory.createConnection().createSession(false, Session.CLIENT_ACKNOWLEDGE);
         MessageProducer producer = mySess.createProducer(destination);


### PR DESCRIPTION
It looks like storm 0.8.2 uses a Long for the topology timeout, even if it's set to an Integer initially, so using a Number works for both.
