### PR TITLE
Added repositories section to streamline maven builds.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,14 @@
 		<developerConnection>scm:git:git@github.com:ptgoetz/storm-jms.git</developerConnection>
 		<url>:git@github.com:ptgoetz/storm-jms.git</url>
 	</scm>
-
+	
+	<repositories>
+                <repository>
+                  <id>clojars.org</id>
+                  <url>http://clojars.org/repo</url>
+                </repository>
+        </repositories>
+	
 	<developers>
 		<developer>
 			<id>ptgoetz</id>


### PR DESCRIPTION
I've added a repository reference for clojars.org, as trying to do a `mvn clean package` results in a dependency resolution failure because storm can't be found:

```
[ERROR] Failed to execute goal on project storm-jms: Could not resolve dependencies for project com.github.ptgoetz:storm-jms:jar:0.8.2-SNAPSHOT: Failure to find storm:storm:jar:0.8.1 in http://repo.maven.apache.org/maven2 was cached in the local repository, resolution will not be reattempted until the update interval of central has elapsed or updates are forced -> [Help 1]
```
